### PR TITLE
feat(song): Implement Song module with Mongoose schema and CRUD APIs

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import { AppService } from './app.service';
 import { validate } from './config/env.validation';
 import { LyricsModule } from './lyrics/lyrics.module';
 import { UserModule } from './user/user.module';
+import { SongModule } from './song/song.module';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { UserModule } from './user/user.module';
     }),
     LyricsModule,
     UserModule,
+    SongModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/dto/song.dto.ts
+++ b/src/dto/song.dto.ts
@@ -1,0 +1,38 @@
+import { IsString, IsNotEmpty, IsOptional, IsInt, Min, Max, IsEnum, ValidateNested, IsBoolean } from "class-validator"
+import { Type } from "class-transformer"
+import { Decade, Genre } from "src/enum/song.enum"
+import { CreateLyricsDto } from "./lyrics.dto"
+
+export class CreateSongDto {
+
+  @IsString()
+  @IsNotEmpty()
+  title!: string
+
+  @IsString()
+  @IsNotEmpty()
+  artist!: string
+
+  @IsString()
+  @IsOptional()
+  album?: string
+
+  @IsInt()
+  @Min(1900)
+  @Max(new Date().getFullYear())
+  @IsOptional()
+  releaseYear?: number
+
+  @IsEnum({Enum: Genre})
+  @IsOptional()
+  genre?: string
+
+  @ValidateNested()
+  @Type(() => CreateLyricsDto)
+  @IsOptional()
+  lyrics?: CreateLyricsDto
+
+  @IsOptional()
+  @IsEnum({Enum: Decade})
+  decade?: string
+}

--- a/src/dto/song.dto.ts
+++ b/src/dto/song.dto.ts
@@ -2,6 +2,7 @@ import { IsString, IsNotEmpty, IsOptional, IsInt, Min, Max, IsEnum, ValidateNest
 import { Type } from "class-transformer"
 import { Decade, Genre } from "src/enum/song.enum"
 import { CreateLyricsDto } from "./lyrics.dto"
+import { PartialType } from "@nestjs/swagger"
 
 export class CreateSongDto {
 
@@ -36,3 +37,5 @@ export class CreateSongDto {
   @IsEnum({Enum: Decade})
   decade?: string
 }
+
+export class UpdateSongDto extends PartialType(CreateSongDto) {}

--- a/src/dto/song.dto.ts
+++ b/src/dto/song.dto.ts
@@ -1,9 +1,10 @@
 import { IsString, IsNotEmpty, IsOptional, IsInt, Min, Max, IsEnum, ValidateNested, IsBoolean } from "class-validator"
-import { Type } from "class-transformer"
+import { Transform, Type } from "class-transformer"
 import { Decade, Genre } from "src/enum/song.enum"
 import { CreateLyricsDto } from "./lyrics.dto"
 import { PartialType } from "@nestjs/swagger"
 
+// Create Song Dto
 export class CreateSongDto {
 
   @IsString()
@@ -38,4 +39,31 @@ export class CreateSongDto {
   decade?: string
 }
 
+// Update Song Dto
 export class UpdateSongDto extends PartialType(CreateSongDto) {}
+
+// Query Song Dto
+export class QuerySongDto extends PartialType(CreateSongDto) {
+
+    @IsOptional()
+    @IsString()
+    search?: string
+  
+    @IsOptional()
+    @IsInt()
+    @Min(1)
+    @Transform(({ value }) => Number.parseInt(value))
+    limit?: number = 10
+  
+    @IsOptional()
+    @IsInt()
+    @Min(0)
+    @Transform(({ value }) => Number.parseInt(value))
+    skip?: number = 0
+  
+    @IsOptional()
+    @IsBoolean()
+    @Transform(({ value }) => value === "true")
+    withLyrics?: boolean = false
+  }
+  

--- a/src/enum/song.enum.ts
+++ b/src/enum/song.enum.ts
@@ -1,0 +1,36 @@
+export enum Genre {
+    Pop = "pop",
+    Rock = "rock",
+    HipHop = "hip-hop",
+    Rap = "rap",
+    RnB = "r&b",
+    Country = "country",
+    Folk = "folk",
+    Jazz = "jazz",
+    Classical = "classical",
+    Electronic = "electronic",
+    Dance = "dance",
+    Reggae = "reggae",
+    Blues = "blues",
+    Metal = "metal",
+    Alternative = "alternative",
+    Indie = "indie",
+    Other = "other",
+  }
+  
+  export enum Decade {
+    "1900s" = "1900s",
+    "1910s" = "1910s",
+    "1920s" = "1920s",
+    "1930s" = "1930s",
+    "1940s" = "1940s",
+    "1950s" = "1950s",
+    "1960s" = "1960s",
+    "1970s" = "1970s",
+    "1980s" = "1980s",
+    "1990s" = "1990s",
+    "2000s" = "2000s",
+    "2010s" = "2010s",
+    "2020s" = "2020s",
+  }
+  

--- a/src/schemas/song.chema.ts
+++ b/src/schemas/song.chema.ts
@@ -1,0 +1,87 @@
+import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose"
+import type { Document } from "mongoose"
+import { Decade, Genre } from "src/enum/song.enum"
+
+export type SongDocument = Song & Document
+
+@Schema({
+  timestamps: true,
+  toJSON: {
+    virtuals: true,
+    transform: (doc, ret) => {
+      ret.id = ret._id
+      delete ret._id
+      delete ret.__v
+      return ret
+    },
+  },
+})
+export class Song {
+  @Prop({ required: true, trim: true, index: true })
+  title!: string
+
+  @Prop({ required: true, trim: true, index: true })
+  artist!: string
+
+  @Prop({ required: false, trim: true })
+  album!: string
+
+  @Prop({
+    required: false,
+    min: 1900,
+    max: new Date().getFullYear(),
+    validate: {
+      validator: Number.isInteger,
+      message: "{VALUE} is not an integer value for release year",
+    },
+  })
+  releaseYear!: number
+
+  @Prop({
+    required: false,
+    enum: Genre,
+  })
+  genre!: string
+
+  @Prop({
+    required: false,
+    type: {
+      content: { type: String, required: true },
+      language: { type: String, required: false, default: "en" },
+    },
+  })
+  lyrics!: {
+    content: string
+    language: string
+  }
+
+  @Prop({
+    required: false,
+    enum: Decade,
+    set: function (this: SongDocument) {
+      if (this.releaseYear) {
+        const decade = Math.floor(this.releaseYear / 10) * 10
+        return `${decade}s`
+      }
+      return undefined
+    },
+  })
+  decade!: string
+
+}
+
+export const SongSchema = SchemaFactory.createForClass(Song)
+
+// Add text indexes for search optimization
+SongSchema.index({ title: "text", artist: "text", album: "text", "lyrics.content": "text" })
+
+
+// Pre-save hook to set decade based on releaseYear
+SongSchema.pre("save", function (next) {
+  if (this.releaseYear && !this.decade) {
+    const decade = Math.floor(this.releaseYear / 10) * 10
+    this.decade = `${decade}s`
+  }
+  next()
+})
+

--- a/src/song/song.controller.ts
+++ b/src/song/song.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('song')
+export class SongController {}

--- a/src/song/song.controller.ts
+++ b/src/song/song.controller.ts
@@ -1,4 +1,79 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, Query, HttpStatus, HttpCode } from "@nestjs/common";
+import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiQuery, ApiBody } from "@nestjs/swagger";
+import type { SongService } from "./song.service";
+import { CreateSongDto, QuerySongDto, UpdateSongDto } from "src/dto/song.dto";
 
-@Controller('song')
-export class SongController {}
+@ApiTags('songs')
+@Controller("songs")
+export class SongController {
+  constructor(private readonly songService: SongService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Create a new song' })
+  @ApiBody({ type: CreateSongDto, description: 'Song data to create' })
+  @ApiResponse({ 
+    status: HttpStatus.CREATED, 
+    description: 'The song has been successfully created.',
+    type: CreateSongDto 
+  })
+  @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: 'Invalid input data.' })
+  create(@Body() createSongDto: CreateSongDto) {
+    return this.songService.create(createSongDto);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'Get all songs' })
+  @ApiQuery({ 
+    name: 'queryDto', 
+    type: QuerySongDto, 
+    required: false,
+    description: 'Query parameters for filtering, pagination, and sorting' 
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'List of songs retrieved successfully',
+    type: [CreateSongDto]
+  })
+  findAll(@Query() queryDto: QuerySongDto) {
+    return this.songService.findAll(queryDto);
+  }
+
+  @Get(":id")
+  @ApiOperation({ summary: 'Get a song by ID' })
+  @ApiParam({ name: 'id', description: 'Song ID' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'The song has been found',
+    type: CreateSongDto
+  })
+  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'Song not found' })
+  findOne(@Param("id") id: string) {
+    return this.songService.findOne(id);
+  }
+
+  @Patch(":id")
+  @ApiOperation({ summary: 'Update a song' })
+  @ApiParam({ name: 'id', description: 'Song ID' })
+  @ApiBody({ type: UpdateSongDto, description: 'Updated song data' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'The song has been successfully updated',
+    type: CreateSongDto
+  })
+  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'Song not found' })
+  @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: 'Invalid input data' })
+  update(@Param("id") id: string, @Body() updateSongDto: UpdateSongDto) {
+    return this.songService.update(id, updateSongDto);
+  }
+
+  @Delete(":id")
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete a song' })
+  @ApiParam({ name: 'id', description: 'Song ID' })
+  @ApiResponse({ status: HttpStatus.NO_CONTENT, description: 'The song has been successfully deleted' })
+  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'Song not found' })
+  remove(@Param("id") id: string) {
+    return this.songService.delete(id);
+  }
+}

--- a/src/song/song.module.ts
+++ b/src/song/song.module.ts
@@ -1,0 +1,4 @@
+import { Module } from '@nestjs/common';
+
+@Module({})
+export class SongModule {}

--- a/src/song/song.module.ts
+++ b/src/song/song.module.ts
@@ -1,4 +1,9 @@
 import { Module } from '@nestjs/common';
+import { SongController } from './song.controller';
+import { SongService } from './song.service';
 
-@Module({})
+@Module({
+  controllers: [SongController],
+  providers: [SongService]
+})
 export class SongModule {}

--- a/src/song/song.module.ts
+++ b/src/song/song.module.ts
@@ -1,9 +1,13 @@
 import { Module } from '@nestjs/common';
-import { SongController } from './song.controller';
+import { MongooseModule } from '@nestjs/mongoose';
 import { SongService } from './song.service';
+import { SongController } from './song.controller';
+import { Song, SongSchema } from 'src/schemas/song.chema';
 
 @Module({
+  imports: [MongooseModule.forFeature([{ name: Song.name, schema: SongSchema }])],
   controllers: [SongController],
-  providers: [SongService]
+  providers: [SongService],
+  exports: [SongService]
 })
 export class SongModule {}

--- a/src/song/song.service.ts
+++ b/src/song/song.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class SongService {}

--- a/src/song/song.service.ts
+++ b/src/song/song.service.ts
@@ -1,4 +1,93 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { InjectModel } from "@nestjs/mongoose";
+import type { Model } from "mongoose";
+import { CreateSongDto, QuerySongDto, UpdateSongDto } from "src/dto/song.dto";
+import { Song, type SongDocument } from "src/schemas/song.chema";
+
 
 @Injectable()
-export class SongService {}
+export class SongService {
+  constructor(@InjectModel(Song.name) private songModel: Model<SongDocument>) {}
+
+  async create(createSongDto: CreateSongDto): Promise<Song> {
+    const createdSong = new this.songModel(createSongDto);
+    return createdSong.save();
+  }
+
+  async findAll(queryDto: QuerySongDto): Promise<{ data: Song[]; total: number }> {
+    const { title, artist, album, releaseYear, genre, decade, search, limit, skip, withLyrics } = queryDto;
+  
+    // Convert limit & skip to numbers with default values
+    const parsedLimit = Number(limit) || 10; 
+    const parsedSkip = Number(skip) || 0;    
+  
+    // Build query
+    const query: any = {};
+  
+    if (title) query.title = { $regex: title, $options: "i" };
+    if (artist) query.artist = { $regex: artist, $options: "i" };
+    if (album) query.album = { $regex: album, $options: "i" };
+    if (releaseYear) query.releaseYear = releaseYear;
+    if (genre) query.genre = genre;
+    if (decade) query.decade = decade;
+  
+    // Text search if provided
+    if (search) {
+      query.$text = { $search: search };
+    }
+  
+    // Create base query
+    let baseQuery = this.songModel.find(query);
+  
+    // Add text score if using text search
+    if (search) {
+      baseQuery = baseQuery.select({ score: { $meta: "textScore" } }).sort({ score: { $meta: "textScore" } });
+    } else {
+      baseQuery = baseQuery.sort({ createdAt: -1 });
+    }
+  
+    // Apply projection correctly
+    if (!withLyrics) {
+      baseQuery = baseQuery.select("-lyrics.content"); 
+    }
+  
+    // Execute query with pagination
+    const data = await baseQuery.limit(parsedLimit).skip(parsedSkip).exec();
+  
+    // Get total count for pagination
+    const total = await this.songModel.countDocuments(query).exec();
+  
+    return { data, total };
+  }
+  
+
+  async findOne(id: string): Promise<Song> {
+    const song = await this.songModel.findById(id).exec();
+    if (!song) {
+      throw new NotFoundException(`Song not found`);
+    }
+    return song;
+  }
+
+  async update(id: string, updateSongDto: UpdateSongDto): Promise<Song> {
+    const updatedSong = await this.songModel.findByIdAndUpdate(id, updateSongDto, { new: true }).exec();
+
+    if (!updatedSong) {
+      throw new NotFoundException(`Song not found`);
+    }
+
+    return updatedSong;
+  }
+
+  async delete(id: string): Promise<void> {
+    const result = await this.songModel.findByIdAndDelete(id).exec();
+
+    if (!result) {
+      throw new NotFoundException(`Song not found`);
+    }
+  }
+
+  async findByIds(ids: string[]): Promise<Song[]> {
+    return this.songModel.find({ _id: { $in: ids } }).exec();
+  }
+}


### PR DESCRIPTION
Created the Song module, including controller and service.
Implemented all the methods within the service and endpoints.
Created Enum for the song containing Genre and Decades.
Defined the Song Mongoose schema with fields: title, artist, album, releaseYear, genre, lyrics, and decade.
Added text indexes for optimized search queries.
Implemented basic CRUD operations for managing songs.